### PR TITLE
[feature/coupong-4] 클라이언트 요청으로부터 오는 JWT 토큰 복호화 API 구현 

### DIFF
--- a/src/main/java/com/onepage/coupong/sign/config/WebSecurityConfig.java
+++ b/src/main/java/com/onepage/coupong/sign/config/WebSecurityConfig.java
@@ -46,8 +46,8 @@ public class WebSecurityConfig {
                 .sessionManagement(sessionManagement -> sessionManagement
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers("/", "api/v1/auth/**", "/oauth2/**").permitAll()
-                        .requestMatchers("/api/v1/user/**").hasRole("USER")
+                        .requestMatchers("api/v1/auth/**", "/oauth2/**").permitAll()
+                        .requestMatchers("/").hasRole("USER")
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         /* 이메일을 보내기 위한 API 허용 */
                         .requestMatchers("/api/v1/mail/**").permitAll()

--- a/src/main/java/com/onepage/coupong/sign/controller/AuthController.java
+++ b/src/main/java/com/onepage/coupong/sign/controller/AuthController.java
@@ -6,14 +6,12 @@ import com.onepage.coupong.sign.dto.request.auth.SignUpRequestDto;
 import com.onepage.coupong.sign.dto.response.auth.IdCheckResponseDto;
 import com.onepage.coupong.sign.dto.response.auth.SignInResponseDto;
 import com.onepage.coupong.sign.dto.response.auth.SignUpResponseDto;
+import com.onepage.coupong.sign.dto.response.auth.TokenResponseDto;
 import com.onepage.coupong.sign.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -48,6 +46,15 @@ public class AuthController {
             @RequestBody @Valid SignInRequestDto requestBody
     ) {
         ResponseEntity<? super SignInResponseDto> response = authService.signIn(requestBody);
+        return response;
+    }
+
+    /* 요청 헤더로부터 받은 Authorization 복호화 후 유저 정보 반환 API */
+    @GetMapping("/tokenDecryption")
+    public ResponseEntity<? super TokenResponseDto> tokenDecryption(
+            @RequestHeader("Authorization") String token
+    ) {
+        ResponseEntity<? super TokenResponseDto> response = authService.tokenDecryption(token);
         return response;
     }
 }

--- a/src/main/java/com/onepage/coupong/sign/controller/AuthController.java
+++ b/src/main/java/com/onepage/coupong/sign/controller/AuthController.java
@@ -25,6 +25,10 @@ public class AuthController {
     /* ID 중복 검사 요청 API */
     @PostMapping("/idCheck")
     public ResponseEntity<? super IdCheckResponseDto> idCheck(
+            /* @RequestBody 옆에 @Valid를 작성하면, RequestBody로 들어오는 객체에 대한 검증을 수행한다.
+            * 검증을 하는 여러 세부적인 사항들 중 몇개만 예시로 들면,
+            * @NotNull : 인자로 들어온 필드 값에 null 값을 허용하지 않는다.
+            * @Email : 인자로 들어온 값을 Email 형식을 갖춰야 한다. */
             @RequestBody @Valid IdCheckRequestDto requestBody
     ) {
         ResponseEntity<? super IdCheckResponseDto> response = authService.idCheck(requestBody);

--- a/src/main/java/com/onepage/coupong/sign/dto/response/auth/SignInResponseDto.java
+++ b/src/main/java/com/onepage/coupong/sign/dto/response/auth/SignInResponseDto.java
@@ -16,7 +16,7 @@ public class SignInResponseDto extends ResponseDto {
 
     private SignInResponseDto(String token) {
         super();
-        this.token = token;
+        this.token = "Bearer " + token;
         /* 만료 시간 1시간을 의미
         * 만료 시간에 대해 수정하고 싶으면 JwtProvider.create() -> expiredDate 수정해주면 됨 */
         expirationTime = 3600;

--- a/src/main/java/com/onepage/coupong/sign/dto/response/auth/TokenResponseDto.java
+++ b/src/main/java/com/onepage/coupong/sign/dto/response/auth/TokenResponseDto.java
@@ -1,0 +1,30 @@
+package com.onepage.coupong.sign.dto.response.auth;
+
+import com.onepage.coupong.entity.enums.Logintype;
+import com.onepage.coupong.entity.enums.UserRole;
+import com.onepage.coupong.sign.dto.response.ResponseDto;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+public class TokenResponseDto extends ResponseDto {
+
+    private String username;
+    private String email;
+    private Logintype logintype;
+    private UserRole role;
+
+    private TokenResponseDto(String username, String email, Logintype logintype, UserRole role) {
+        super();
+        this.username = username;
+        this.email = email;
+        this.logintype = logintype;
+        this.role = role;
+    }
+
+    public static ResponseEntity<TokenResponseDto> success(String username, String email, Logintype logintype, UserRole role) {
+        TokenResponseDto responseBody = new TokenResponseDto(username, email, logintype, role);
+        return ResponseEntity.status(HttpStatus.OK).body(responseBody);
+    }
+}

--- a/src/main/java/com/onepage/coupong/sign/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/onepage/coupong/sign/filter/JwtAuthenticationFilter.java
@@ -55,18 +55,23 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             /* ROLE_USER, ROLE_ADMIN */
             String role = String.valueOf(user.getRole());
 
+            /* GrantedAuthority 는 현재 사용자(principal)가 가지고 있는 권한을 의미한다.
+            *  ROLE_ADMIN, ROLE_USER 와 같이 ROLE_*의 형태로 사용한다.
+            *  GrantedAuthority 객체는 UserDetailsService에 의해 불러올 수 있고
+            *  특정 자원에 대한 권한이 있는지를 검사해 접근 허용 여부를 결정한다. */
             List<GrantedAuthority> authorities = new ArrayList<>();
             authorities.add(new SimpleGrantedAuthority(role));
 
-            /* 토큰에 들어갈 context 객체를 만들어준다. */
+            /* 토큰이 들어갈 context 객체를 만들어준다. */
             SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
 
-
-            AbstractAuthenticationToken authenticationToken =
+            UsernamePasswordAuthenticationToken authenticationToken =
                     /* 첫 번째 위치에는 User의 정보, 두 번째 위치는 Password, 그 이후에는 여기서는 권한을 추가적으로 넣어줬다. */
                     new UsernamePasswordAuthenticationToken(username, null, authorities);
 
-            authenticationToken.setDetails(new WebAuthenticationDetailsSource());
+            /* Authentication 설정 추가 */
+            securityContext.setAuthentication(authenticationToken);
+
             SecurityContextHolder.setContext(securityContext);
 
         } catch (Exception e) {

--- a/src/main/java/com/onepage/coupong/sign/service/AuthService.java
+++ b/src/main/java/com/onepage/coupong/sign/service/AuthService.java
@@ -6,6 +6,7 @@ import com.onepage.coupong.sign.dto.request.auth.SignUpRequestDto;
 import com.onepage.coupong.sign.dto.response.auth.IdCheckResponseDto;
 import com.onepage.coupong.sign.dto.response.auth.SignInResponseDto;
 import com.onepage.coupong.sign.dto.response.auth.SignUpResponseDto;
+import com.onepage.coupong.sign.dto.response.auth.TokenResponseDto;
 import org.springframework.http.ResponseEntity;
 
 public interface AuthService {
@@ -20,4 +21,7 @@ public interface AuthService {
 
     /* 로그인 서비스 */
     ResponseEntity<? super SignInResponseDto> signIn(SignInRequestDto dto);
+
+    /* 요청 헤더로부터 받은 Authorization 복호화 후 유저 정보 반환 서비스 */
+    ResponseEntity<? super TokenResponseDto> tokenDecryption(String token);
 }

--- a/src/main/java/com/onepage/coupong/sign/service/implement/AuthServiceImpl.java
+++ b/src/main/java/com/onepage/coupong/sign/service/implement/AuthServiceImpl.java
@@ -155,6 +155,12 @@ public class AuthServiceImpl implements AuthService {
         UserRole role = null;
 
         try {
+            boolean isBearer = token.startsWith("Bearer ");
+            if (!isBearer) {
+                return ResponseDto.validationFailed();
+            }
+            token = token.substring(7);
+
             /* jjwt 라이브러리와 개인키(secretKey)를 이용해서 signature를 복호화하는 과정으로
             *  setSigngKey()가 개인키를 복호화해준다. */
             Claims claim =


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - [Notion-Ticket] : X
    - [Notion-API] : X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 클라이언트 요청 헤더에 포함되어 있는 JWT 토큰을 복호화해 필요한 유저의 정보를 가져올 수 있도록 하는 API 구현

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - X

> ## 📲&nbsp;&nbsp;마이그레이션 여부

    - [마이그레이션_APP] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
