### PR TITLE
[feature/coupong-6] 쿠폰 등록 및 이벤트 관리를 위한 관리자 기능 추가

### DIFF
--- a/src/main/java/com/onepage/coupong/controller/CouponEventController.java
+++ b/src/main/java/com/onepage/coupong/controller/CouponEventController.java
@@ -2,24 +2,32 @@ package com.onepage.coupong.controller;
 
 import com.onepage.coupong.dto.UserRequestDto;
 import com.onepage.coupong.service.CouponEventService;
+import com.onepage.coupong.sign.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/coupon")
+@RequiredArgsConstructor
 public class CouponEventController {
 
+    private static final Logger log = LoggerFactory.getLogger(CouponEventController.class);
     private final CouponEventService couponEventService;
-
-    public CouponEventController(CouponEventService couponEventService) {
-        this.couponEventService = couponEventService;
-    }
+    private final AuthService authService;
 
     @PostMapping("/attempt")
-    public ResponseEntity<String> requestCoupon(@RequestBody UserRequestDto userRequestDto, @RequestHeader("Authorization") String token) {
-        boolean publishSuccess = couponEventService.addUserToQueue(userRequestDto);  //JWT 토큰으로 user_id 받도록 해야됨
+    public ResponseEntity<String> requestCoupon(
+            @RequestBody UserRequestDto userRequestDto, @RequestHeader("Authorization") String token
+    ) {
+        /* 헤더로부터 받아온 JWT 토큰 정보로부터 유저 ID 반환 후 userRequestDto에 입력 */
+        Long userId = authService.tokenDecryptionId(token);
+        userRequestDto.setId(userId);
 
+        boolean publishSuccess = couponEventService.addUserToQueue(userRequestDto);
         if (publishSuccess) {
             return ResponseEntity.ok("쿠폰 발급 요청에 성공했습니다 - 대기열 등록 -");
         } else {

--- a/src/main/java/com/onepage/coupong/dto/UserRequestDto.java
+++ b/src/main/java/com/onepage/coupong/dto/UserRequestDto.java
@@ -11,8 +11,6 @@ import lombok.Setter;
 @Builder
 public class UserRequestDto {
     private Long id;
-    private String username;
-    private String email;
     private CouponCategory couponCategory;
     private final long attemptAt = System.currentTimeMillis();
 }

--- a/src/main/java/com/onepage/coupong/sign/config/WebSecurityConfig.java
+++ b/src/main/java/com/onepage/coupong/sign/config/WebSecurityConfig.java
@@ -48,7 +48,7 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests(request -> request
                         .requestMatchers("api/v1/auth/**", "/oauth2/**").permitAll()
                         .requestMatchers("/").hasRole("USER")
-                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/admin").hasRole("ADMIN")
                         /* 이메일을 보내기 위한 API 허용 */
                         .requestMatchers("/api/v1/mail/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/onepage/coupong/sign/dto/response/auth/SignInResponseDto.java
+++ b/src/main/java/com/onepage/coupong/sign/dto/response/auth/SignInResponseDto.java
@@ -1,5 +1,6 @@
 package com.onepage.coupong.sign.dto.response.auth;
 
+import com.onepage.coupong.entity.enums.UserRole;
 import com.onepage.coupong.sign.common.ResponseCode;
 import com.onepage.coupong.sign.common.ResponseMessage;
 import com.onepage.coupong.sign.dto.response.ResponseDto;
@@ -10,20 +11,23 @@ import org.springframework.http.ResponseEntity;
 @Getter
 public class SignInResponseDto extends ResponseDto {
 
-    /* 로그인이 성공할 경우 token과 만료시간에 대한 데이터도 넘겨주기 위함 */
+    /* 로그인이 성공할 경우 token과 만료시간, 권한에 대한 데이터도 넘겨주기 위함 */
     private String token;
     private int expirationTime;
 
-    private SignInResponseDto(String token) {
+    private UserRole role;
+
+    private SignInResponseDto(String token, UserRole role) {
         super();
         this.token = "Bearer " + token;
         /* 만료 시간 1시간을 의미
         * 만료 시간에 대해 수정하고 싶으면 JwtProvider.create() -> expiredDate 수정해주면 됨 */
         expirationTime = 3600;
+        this.role = role;
     }
 
-    public static ResponseEntity<SignInResponseDto> success(String token) {
-        SignInResponseDto responseBody = new SignInResponseDto(token);
+    public static ResponseEntity<SignInResponseDto> success(String token, UserRole role) {
+        SignInResponseDto responseBody = new SignInResponseDto(token, role);
         return ResponseEntity.status(HttpStatus.OK).body(responseBody);
     }
 

--- a/src/main/java/com/onepage/coupong/sign/service/AuthService.java
+++ b/src/main/java/com/onepage/coupong/sign/service/AuthService.java
@@ -24,4 +24,7 @@ public interface AuthService {
 
     /* 요청 헤더로부터 받은 Authorization 복호화 후 유저 정보 반환 서비스 */
     ResponseEntity<? super TokenResponseDto> tokenDecryption(String token);
+
+    /* 요청 헤더로부터 받은 JWT 토큰을 복호화 후 유저 ID로 반환 서비스 */
+    Long tokenDecryptionId(String token);
 }

--- a/src/main/java/com/onepage/coupong/sign/service/implement/AuthServiceImpl.java
+++ b/src/main/java/com/onepage/coupong/sign/service/implement/AuthServiceImpl.java
@@ -114,8 +114,9 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public ResponseEntity<? super SignInResponseDto> signIn(SignInRequestDto dto) {
 
-        /* 로그인이 성공적으로 되면 token을 생성해서 보내줘야함. */
+        /* 로그인이 성공적으로 되면 token과 권한에 대한 정보를 생성해서 보내줘야함. */
         String token = null;
+        UserRole role;
 
         try {
             /* 로그인 요청에 입력한 username이 DB에 존재하지 않으면 로그인 실패 에러를 보내준다. */
@@ -137,13 +138,15 @@ public class AuthServiceImpl implements AuthService {
             /* 로그인이 성공한 경우 토큰 생성 */
             token = jwtProvider.create(username);
 
+            role = user.getRole();
+
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseDto.databaseError();
         }
 
         /* 성공 코드, 메시지와 토큰을 함께 보내준다. */
-        return SignInResponseDto.success(token);
+        return SignInResponseDto.success(token, role);
     }
 
     @Override

--- a/src/main/java/com/onepage/coupong/sign/service/implement/AuthServiceImpl.java
+++ b/src/main/java/com/onepage/coupong/sign/service/implement/AuthServiceImpl.java
@@ -183,4 +183,33 @@ public class AuthServiceImpl implements AuthService {
         }
         return TokenResponseDto.success(username, email, logintype, role);
     }
+
+    @Override
+    public Long tokenDecryptionId(String token) {
+        Long userId = null;
+        try {
+            boolean isBearer = token.startsWith("Bearer ");
+            if (!isBearer) {
+                return null;
+            }
+            token = token.substring(7);
+
+            /* jjwt 라이브러리와 개인키(secretKey)를 이용해서 signature를 복호화하는 과정으로
+             *  setSigngKey()가 개인키를 복호화해준다. */
+            Claims claim =
+                    Jwts.parserBuilder().setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8)).build().parseClaimsJws(token).getBody();
+
+            String getUsername = claim.getSubject();
+            User user = userRepository.findUserByUsername(getUsername);
+
+            if (user == null) {
+                return null;
+            }
+            userId = user.getId();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+        return userId;
+    }
 }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - [Notion-Ticket] : X
    - [Notion-API] : X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 로그인 성공시 토큰정보만 응답으로 보내왔던 기존버전에서 로그인 성공시 유저/관리자를 구분할 수 있는 role 정보를 응답에 추가해서 보내주고, 관리자 페이지에는 관리자만 들어갈 수 있도록 security 설정 수정

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 현제 일반 유저인 경우 오직 메인페이지에만 들어갈 수 있지만, 관리자는 메인페이지 및 관리자 페이지 모두 들어갈 수 있다. 관리자도 메인페이지를 접속하지 못하도록 해야하는지 회의 필요

> ## 💾&nbsp;&nbsp;RDB 업데이트 여부

    - [마이그레이션_APP] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
